### PR TITLE
[KP-210] 스캔후 폴더생성 다이얼로그 예외처리

### DIFF
--- a/data/src/main/java/com/keeply/data/screenshot/OcrRepositoryImpl.kt
+++ b/data/src/main/java/com/keeply/data/screenshot/OcrRepositoryImpl.kt
@@ -16,13 +16,15 @@ class OcrRepositoryImpl @Inject constructor(
 ) : OcrRepository {
     override suspend fun analyzeImage(
         isNew: Boolean,
-        imageId: Long?,
+        imageId: Int?,
+        isSkip: Boolean,
         file: File
     ): Flow<ScanAnalyze> = flow {
         emit(
             ocrService.analyzeImage(
                 isNew = isNew.toString().toPlainRequestBody(),
                 imageId = imageId?.toString()?.toPlainRequestBody(),
+                isSkip = isSkip.toString().toPlainRequestBody(),
                 file = file.toMultipartPart()
             ).response.toDomain()
         )

--- a/data/src/main/java/com/keeply/data/screenshot/mapper/ScanAnlyzeMapper.kt
+++ b/data/src/main/java/com/keeply/data/screenshot/mapper/ScanAnlyzeMapper.kt
@@ -6,6 +6,5 @@ import com.keeply.domain.model.ScanAnalyze
 
 fun ScanAnalyzeResponse?.toDomain() = ScanAnalyze(
     cachedImageId = this?.cachedImageId.default(),
-    detectedText = this?.detectedText.default(),
-    recommendedTags = this?.recommendedTags.default()
+    detectedText = this?.detectedText.default()
 )

--- a/data/src/main/java/com/keeply/data/screenshot/model/ScanAnalyzeResponse.kt
+++ b/data/src/main/java/com/keeply/data/screenshot/model/ScanAnalyzeResponse.kt
@@ -5,6 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ScanAnalyzeResponse(
     val cachedImageId: String?,
-    val detectedText: String?,
-    val recommendedTags: List<String>?,
+    val detectedText: String?
 )

--- a/data/src/main/java/com/keeply/data/screenshot/remote/OcrService.kt
+++ b/data/src/main/java/com/keeply/data/screenshot/remote/OcrService.kt
@@ -15,6 +15,7 @@ interface OcrService {
     suspend fun analyzeImage(
         @Part("isNew") isNew: RequestBody,
         @Part("imageId") imageId: RequestBody?,
+        @Part("isSkip") isSkip: RequestBody,
         @Part file: MultipartBody.Part
     ): BaseResponse<ScanAnalyzeResponse>
 }

--- a/domain/src/main/java/com/keeply/domain/model/ScanAnalyze.kt
+++ b/domain/src/main/java/com/keeply/domain/model/ScanAnalyze.kt
@@ -2,6 +2,5 @@ package com.keeply.domain.model
 
 data class ScanAnalyze(
     val cachedImageId: String?,
-    val detectedText: String?,
-    val recommendedTags: List<String>?
+    val detectedText: String?
 )

--- a/domain/src/main/java/com/keeply/domain/repository/OcrRepository.kt
+++ b/domain/src/main/java/com/keeply/domain/repository/OcrRepository.kt
@@ -1,10 +1,9 @@
 package com.keeply.domain.repository
 
 import com.keeply.domain.model.ScanAnalyze
-import com.keeply.domain.model.ScanImage
 import kotlinx.coroutines.flow.Flow
 import java.io.File
 
 interface OcrRepository {
-    suspend fun analyzeImage(isNew: Boolean, imageId: Long?, file: File): Flow<ScanAnalyze>
+    suspend fun analyzeImage(isNew: Boolean, imageId: Int?, isSkip: Boolean, file: File): Flow<ScanAnalyze>
 }

--- a/domain/src/main/java/com/keeply/domain/usecase/scan/ScanImageUseCase.kt
+++ b/domain/src/main/java/com/keeply/domain/usecase/scan/ScanImageUseCase.kt
@@ -1,10 +1,9 @@
 package com.keeply.domain.usecase.scan
 
 import com.keeply.domain.model.ScanAnalyze
-import com.keeply.domain.model.ScanImage
 import kotlinx.coroutines.flow.Flow
 import java.io.File
 
 interface ScanImageUseCase {
-    suspend operator fun invoke(isNew: Boolean, imageId: Long?, file: File): Flow<ScanAnalyze>
+    suspend operator fun invoke(isNew: Boolean, imageId: Int?, isSkip: Boolean, file: File): Flow<ScanAnalyze>
 }

--- a/domain/src/main/java/com/keeply/domain/usecase/scan/ScanImageUseCaseImpl.kt
+++ b/domain/src/main/java/com/keeply/domain/usecase/scan/ScanImageUseCaseImpl.kt
@@ -9,6 +9,6 @@ import javax.inject.Inject
 class ScanImageUseCaseImpl @Inject constructor(
     val repository: OcrRepository
 ) : ScanImageUseCase {
-    override suspend fun invoke(isNew: Boolean, imageId: Long?, file: File): Flow<ScanAnalyze> =
-        repository.analyzeImage(isNew, imageId, file)
+    override suspend fun invoke(isNew: Boolean, imageId: Int?, isSkip: Boolean, file: File): Flow<ScanAnalyze> =
+        repository.analyzeImage(isNew, imageId, isSkip, file)
 }

--- a/presentation/src/main/java/com/keeply/presentation/core/components/TextFields.kt
+++ b/presentation/src/main/java/com/keeply/presentation/core/components/TextFields.kt
@@ -28,6 +28,7 @@ import com.keeply.presentation.core.theme.KeeplyTheme
 @Composable
 fun KeeplyTextField(
     modifier: Modifier = Modifier,
+    inputModifier: Modifier = Modifier, // todo Textfield 타입 추가 후 제거
     value: String,
     onValueChange: (String) -> Unit,
     placeholder: String = "",
@@ -52,7 +53,7 @@ fun KeeplyTextField(
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         Row(
-            modifier = Modifier
+            modifier = inputModifier
                 .fillMaxWidth()
                 .height(40.dp)
                 .border(

--- a/presentation/src/main/java/com/keeply/presentation/ui/folder/add/AddFolderViewModel.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/folder/add/AddFolderViewModel.kt
@@ -36,7 +36,8 @@ class AddFolderViewModel @Inject constructor(
                     val errorMessage = exception.message ?: "폴더 생성에 실패했습니다."
                     postSideEffect(AddFolderSideEffect.ShowError(errorMessage))
                 }
-                .collect { folder ->
+                .collect {
+                    reduce { state.copy(folderName = "", folderColor = FolderColor.ORANGE) }
                     postSideEffect(AddFolderSideEffect.ShowCreateSuccess)
                 }
         } else {

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/navigation/ScanNavHost.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/navigation/ScanNavHost.kt
@@ -34,8 +34,8 @@ fun ScanNavHost(
                 onNavigateToCrop = { uri ->
                     navigator.navController.navigate(ScanRoute.ScanCrop(Uri.encode(uri.toString())))
                 },
-                onNavigateToScanAfter = { uri, result ->
-                    navigator.navController.navigate(ScanRoute.ScanAfter(Uri.encode(uri.toString()), result.cachedImageId, result.detectedText, result.recommendedTags))
+                onNavigateToScanAfter = { uri, result, isSkip ->
+                    navigator.navController.navigate(ScanRoute.ScanAfter(Uri.encode(uri.toString()), result.cachedImageId, result.detectedText, isSkip))
                 }
             )
         }

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/navigation/ScanRouteModel.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/navigation/ScanRouteModel.kt
@@ -24,6 +24,6 @@ sealed interface ScanRoute: ScanRouteModel {
         val url: String,
         val cachedImageId: String?,
         val detectedText: String?,
-        val recommendedTags: List<String>?
+        val isSkip: Boolean
     ) : ScanRouteModel
 }

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/AddFolderModal.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/AddFolderModal.kt
@@ -38,7 +38,11 @@ fun AddFolderModal(
     onCreateFolder: () -> Unit = {},
     onNavigateBack: () -> Unit = {},
 ) {
-    BaseAlertModal {
+    BaseAlertModal(
+        onDismissCallback = onNavigateBack,
+        dismissOnBackPress = true,
+        dismissOnClickOutside = true
+    ) {
         Column(
             modifier = Modifier
                 .padding(16.dp)

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/AddFolderModal.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/AddFolderModal.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,6 +27,7 @@ import com.keeply.presentation.core.components.KeeplyTextField
 import com.keeply.presentation.core.components.colorBar.ColorBar
 import com.keeply.presentation.core.components.colorBar.FolderColor
 import com.keeply.presentation.core.theme.KeeplyTheme
+import com.keeply.presentation.core.theme.neutral100
 import com.keeply.presentation.core.theme.neutral200
 import com.keeply.presentation.core.theme.neutral600
 import com.keeply.presentation.ui.folder.add.AddFolderState
@@ -82,6 +84,8 @@ fun AddFolderModal(
                 modifier = Modifier
                     .padding(top = 16.dp)
                     .fillMaxWidth(),
+                inputModifier = Modifier
+                    .background(neutral100, RoundedCornerShape(4.dp)),
                 value = state.folderName,
                 onValueChange = onFolderNameChange,
                 helpIcon = if (state.checkFolderRegex()) null else KeeplyTheme.icons.error,

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/AddFolderModal.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/AddFolderModal.kt
@@ -77,16 +77,16 @@ fun AddFolderModal(
                     .background(neutral200)
             )
 
+            // TODO: 디자인 수정 필요
             KeeplyTextField(
                 modifier = Modifier
                     .padding(top = 16.dp)
-                    .background(KeeplyTheme.colors.neutral100)
                     .fillMaxWidth(),
                 value = state.folderName,
                 onValueChange = onFolderNameChange,
                 helpIcon = if (state.checkFolderRegex()) null else KeeplyTheme.icons.error,
-                helpText = if (state.checkFolderRegex()) "" else "최대 20자까지 입력 가능합니다.",
-                placeholder = "폴더명"
+                helpText = if (state.checkFolderRegex()) "" else "최소 1자 미만. 최대 20자까지 입력해주세요.",
+                placeholder = "새 폴더"
             )
 
             KeeplyText(

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/ScanAfterContract.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/ScanAfterContract.kt
@@ -10,7 +10,6 @@ data class ScanAfterState(
     val uri: String,
     val cachedImageId: String = "",
     val detectedText: String? = null,
-    val recommendedTags: ImmutableList<String>? = null,
     val detectedTextList: ImmutableList<String> = persistentListOf(),
     val selectedIndices: ImmutableList<Int> = persistentListOf(),
     val textField: String = "",

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/ScanAfterViewModel.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/ScanAfterViewModel.kt
@@ -37,7 +37,7 @@ class ScanAfterViewModel @Inject constructor(
                 } else {
                     scanAfter.detectedText.split("\n")
                 }.toPersistentList(),
-                recommendedTags = scanAfter.recommendedTags?.toPersistentList()
+                showSelectTextBottomSheet = scanAfter.isSkip.not()
             )
         )
 

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeScreen.kt
@@ -70,7 +70,7 @@ import org.orbitmvi.orbit.compose.collectAsState
 fun ScanBeforeRoute(
     onBack: () -> Unit,
     onNavigateToCrop: (Uri) -> Unit,
-    onNavigateToScanAfter: (Uri, ScanAnalyze) -> Unit,
+    onNavigateToScanAfter: (Uri, ScanAnalyze, Boolean) -> Unit,
     viewModel: ScanBeforeViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -86,29 +86,13 @@ fun ScanBeforeRoute(
         onNavigateToCrop = onNavigateToCrop,
         doNotRepeatButtonCallback = { viewModel.onDoNotShowAgain() },
         callScan = { imageUri ->
-            // real -> Crop후 imageUri 사용하도록 수정하는게 좋을 듯함
+            // TODO real -> Crop후 imageUri 사용하도록 수정하는게 좋을 듯함
             viewModel.scanImage(
                 image = uiState.uri.toUri().toFile(context),
                 successCallback = { result ->
-                    onNavigateToScanAfter(uiState.uri.toUri(), result)
+                    onNavigateToScanAfter(uiState.uri.toUri(), result, false)
                 }
             )
-            
-            // for test (OCR 하지 앟는 임시 버전)
-//            onNavigateToScanAfter(
-//                imageUri,
-//                ScanAnalyze(
-//                    recommendedTags = null,
-//                    cachedImageId = null,
-//                    detectedText = "하이하이\n다음말이다\n반갑소\n이러한 책 속의 인용들을 보며, 나는 좋은 문구를 기록만 해두는 경우가 많은데, 잘 활용하는 것도 중요하단 생각을 많이 했다.\n하이하이\n" +
-//                            "다음말이다\n" +
-//                            "반갑소\n" +
-//                            "이러한 책 속의 인용들을 보며, 나는 좋은 문구를 기록만 해두는 경우가 많은데, 잘 활용하는 것도 중요하단 생각을 많이 했다.\n하이하이\n" +
-//                            "다음말이다\n" +
-//                            "반갑소\n" +
-//                            "이러한 책 속의 인용들을 보며, 나는 좋은 문구를 기록만 해두는 경우가 많은데, 잘 활용하는 것도 중요하단 생각을 많이 했다."
-//                )
-//            )
         }
     )
 }

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeViewModel.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeViewModel.kt
@@ -59,6 +59,7 @@ class ScanBeforeViewModel @Inject constructor(
 
     fun scanImage(
         image: File?,
+        isSkip: Boolean = false,
         successCallback: (ScanAnalyze) -> Unit
     ) = viewModelScope.launch {
         if (image == null) return@launch
@@ -67,6 +68,7 @@ class ScanBeforeViewModel @Inject constructor(
         scanImageUseCase(
             isNew = true,
             imageId = null,
+            isSkip = isSkip,
             file = image
         ).catch {
             it.stackTrace
@@ -75,7 +77,6 @@ class ScanBeforeViewModel @Inject constructor(
             onScanComplete(true)
             successCallback(it)
             onOcrResult(it)
-            Log.d("euzl", "scanImage: $it") // for test
         }
     }
 


### PR DESCRIPTION
## 작업 내용
- [[KP-210-2] 폴더 생성후 폴더의 이름과 색상 초기화](https://github.com/DDD-Community/DDD-12-Keeply-Android/commit/ac41bf718be06b7b695b3bb79a211ee214b81299)
- [[KP-210-3] 폴더 생성 모달 닫기 시나리오 추가 (시스템뒤로가기 등)](https://github.com/DDD-Community/DDD-12-Keeply-Android/commit/10c5e4aca50c68b12fde1e8c1cd05c35d0e171bc)
- [[KP-210-4] 디자인 임시 적용](https://github.com/DDD-Community/DDD-12-Keeply-Android/commit/18c5d41063b4ea7bbda6a9e1c08d0678c28d2e83)
- [[KP-210-5] 폴더 생성시 help문구 변경](https://github.com/DDD-Community/DDD-12-Keeply-Android/commit/5fd196d628dfea9ed0f4c21388874fc5f7e99422)
<br>

## 확인 사항
- [x] 폴더생성시 바깥부분 클릭하여 폴더생성모달 사라지는지
- [x] 폴더명 1자 미만, 20자 초과시 저장 안되는것확인

<br>

## 참고
-
<br>