### PR TITLE
Home Screen 여백 조정

### DIFF
--- a/presentation/src/main/java/com/keeply/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/home/HomeScreen.kt
@@ -204,7 +204,7 @@ fun HomeScreen(
                     LazyRow(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 12.dp, bottom = 38.dp),
+                            .padding(top = 12.dp),
                         horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
                         item { Spacer(modifier = Modifier.size(4.dp)) }
@@ -225,7 +225,7 @@ fun HomeScreen(
 
                 Column(
                     modifier = Modifier
-                        .padding(top = 38.dp, start = 16.dp, end = 16.dp)
+                        .padding(top = 36.dp, start = 16.dp, end = 16.dp)
                 ) {
                     if (homeData.recentFolders.isNotEmpty()) {
                         Row(


### PR DESCRIPTION
## 작업 내용
- Home Screen 최근 스크린샷 과 최근 업데이트된 폴더 사이의 여백 조정

|전|후|
|--|--|
|<img width="282" height="608" alt="스크린샷 2025-08-22 오전 2 54 40" src="https://github.com/user-attachments/assets/7dff92b3-278d-4dda-b41a-05c6fcd37075" />|<img width="282" height="611" alt="스크린샷 2025-08-22 오전 2 57 22" src="https://github.com/user-attachments/assets/58cc5a48-da60-4f65-81de-4ee642ce199d" />|

<br>

## 확인 사항
- [ ] 여백확인


<br>

## 참고
- 
<br>