### PR TITLE
[KP-202-2] 스캔 온보딩모달 다시보지 않기 후 깜빡현상 수정

### DIFF
--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/navigation/ScanNavHost.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/navigation/ScanNavHost.kt
@@ -23,8 +23,8 @@ fun ScanNavHost(
         composable<ScanRoute.ScanScreenShot> {
             ScreenshotRoute(
                 onBack = onNavigateBack,
-                onNavigateToDetail = { uri ->
-                    navigator.navController.navigate(ScanRoute.ScanBefore(Uri.encode(uri.toString())))
+                onNavigateToScanBefore = { uri, isShowOnBoarding ->
+                    navigator.navController.navigate(ScanRoute.ScanBefore(Uri.encode(uri.toString()), isShowOnBoarding))
                 }
             )
         }

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/navigation/ScanRouteModel.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/navigation/ScanRouteModel.kt
@@ -1,17 +1,17 @@
 package com.keeply.presentation.ui.scan.navigation
 
-import com.keeply.domain.model.ScanAnalyze
 import kotlinx.serialization.Serializable
 
 sealed interface ScanRouteModel
 
-sealed interface ScanRoute: ScanRouteModel {
+sealed interface ScanRoute : ScanRouteModel {
     @Serializable
     data object ScanScreenShot : ScanRouteModel
 
     @Serializable
     data class ScanBefore(
-        val url: String
+        val url: String,
+        val isShowOnBoarding: Boolean = false
     ) : ScanRouteModel
 
     @Serializable

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeContract.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeContract.kt
@@ -6,8 +6,7 @@ import com.keeply.domain.model.ScanAnalyze
 @Immutable
 data class ScanBeforeState(
     val uri: String,
-    val textField: String = "",
-    val textFieldMaxLength: Int = 300,
+    val isShowOnBoarding: Boolean = false,
     val isScanCompleted: Boolean = false,
     val ocrResult: ScanAnalyze? = null
 )

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -76,15 +75,15 @@ fun ScanBeforeRoute(
     val context = LocalContext.current
 
     val uiState by viewModel.collectAsState()
-    val isShowOnBoarding by viewModel.showOnBoardingModal.collectAsState()
 
     ScanBeforeScreen(
         uri = uiState.uri.toUri(),
-        isShowOnBoarding = isShowOnBoarding,
+        isShowOnBoarding = uiState.isShowOnBoarding,
         isScanCompleted = uiState.isScanCompleted,
         onBack = onBack,
         onNavigateToCrop = onNavigateToCrop,
-        doNotRepeatButtonCallback = { viewModel.onDoNotShowAgain() },
+        onBoardingConfirmCallback = { viewModel.onBoardingConfirmClicked() },
+        onBoardingDisabledCallback = { viewModel.onBoardingNeverShowClicked() },
         callScan = { imageUri ->
             // TODO real -> Crop후 imageUri 사용하도록 수정하는게 좋을 듯함
             viewModel.scanImage(
@@ -104,14 +103,14 @@ fun ScanBeforeScreen(
     isScanCompleted: Boolean = false,
     onBack: () -> Unit,
     onNavigateToCrop: (Uri) -> Unit,
-    doNotRepeatButtonCallback: () -> Unit,
+    onBoardingConfirmCallback: () -> Unit,
+    onBoardingDisabledCallback: () -> Unit,
     callScan: (Uri) -> Unit = {}
 ) {
     if (uri == null) return // 모달을 띄우거나 ~
 
     Log.d("TAG", "ScanBeforeScreen: $uri")
     var isMenuVisible by remember { mutableStateOf(true) }
-    var isShowDialog by remember { mutableStateOf(true) }
     var isScanLoading by remember { mutableStateOf(false) }
 
     Box(
@@ -120,10 +119,10 @@ fun ScanBeforeScreen(
             .background(neutral900)
     ) {
 
-        if (isShowOnBoarding && isShowDialog) {
+        if (isShowOnBoarding) {
             ScanOnBoardingModal(
-                confirmButtonCallback = { isShowDialog = !isShowDialog },
-                doNotRepeatButtonCallback = { doNotRepeatButtonCallback() }
+                onBoardingConfirmCallback = onBoardingConfirmCallback,
+                onBoardingDisabledCallback = onBoardingDisabledCallback
             )
         }
 
@@ -269,17 +268,17 @@ fun ScanBeforeScreen(
 
 @Composable
 fun ScanOnBoardingModal(
-    confirmButtonCallback: () -> Unit,
-    doNotRepeatButtonCallback: () -> Unit
+    onBoardingConfirmCallback: () -> Unit,
+    onBoardingDisabledCallback: () -> Unit
 ) {
     BaseAlertModal(
-        onDismissCallback = confirmButtonCallback,
+        onDismissCallback = onBoardingConfirmCallback,
         underContent = {
             KeeplyText(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .padding(top = 12.dp)
-                    .clickable { doNotRepeatButtonCallback() },
+                    .clickable { onBoardingDisabledCallback() },
                 text = buildAnnotatedString {
                     withStyle(style = SpanStyle(textDecoration = TextDecoration.Underline)) {
                         append("다시 보지 않기")
@@ -333,7 +332,7 @@ fun ScanOnBoardingModal(
                     modifier = Modifier
                         .weight(1f),
                     text = stringResource(R.string.scan_onboarding_confirm),
-                    onClick = confirmButtonCallback
+                    onClick = onBoardingConfirmCallback
                 )
             }
         }
@@ -347,7 +346,8 @@ private fun ScanScreenPreview() {
         ScanBeforeScreen(
             onBack = { },
             onNavigateToCrop = { },
-            doNotRepeatButtonCallback = { }
+            onBoardingConfirmCallback = { },
+            onBoardingDisabledCallback = { }
         )
     }
 }

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeViewModel.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeViewModel.kt
@@ -7,15 +7,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.keeply.domain.model.ScanAnalyze
-import com.keeply.domain.model.ScanImage
-import com.keeply.domain.usecase.scan.GetScanOnBoardingVisibilityUseCase
 import com.keeply.domain.usecase.scan.ScanImageUseCase
 import com.keeply.domain.usecase.scan.SetDoNotShowDialogUseCase
 import com.keeply.presentation.ui.scan.navigation.ScanRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
@@ -26,32 +22,30 @@ import javax.inject.Inject
 @HiltViewModel
 class ScanBeforeViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
-    getScanOnBoardingVisibilityUseCase: GetScanOnBoardingVisibilityUseCase,
     private val setDoNotShowDialogUseCase: SetDoNotShowDialogUseCase,
     private val scanImageUseCase: ScanImageUseCase
 ) : ContainerHost<ScanBeforeState, ScanBeforeSideEffect>, ViewModel() {
-    val scanBefore: ScanRoute.ScanBefore = savedStateHandle.toRoute()
 
-    fun onValueChange(value: String) = intent {
-        reduce {
-            state.copy(
-                textField = value
-            )
-        }
-    }
+    private val scanBefore: ScanRoute.ScanBefore = savedStateHandle.toRoute()
 
     override val container: Container<ScanBeforeState, ScanBeforeSideEffect> =
         container(
             ScanBeforeState(
-                Uri.decode(scanBefore.url)
+                uri = Uri.decode(scanBefore.url),
+                isShowOnBoarding = scanBefore.isShowOnBoarding
             )
         )
 
-    // 온보딩 모달 노출 여부
-    val showOnBoardingModal = getScanOnBoardingVisibilityUseCase()
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
+    fun onBoardingConfirmClicked() = intent {
+        reduce {
+            state.copy(
+                isShowOnBoarding = false
+            )
+        }
+    }
 
-    fun onDoNotShowAgain() {
+    fun onBoardingNeverShowClicked() {
+        onBoardingConfirmClicked()
         viewModelScope.launch {
             setDoNotShowDialogUseCase(true)
         }
@@ -80,7 +74,7 @@ class ScanBeforeViewModel @Inject constructor(
         }
     }
 
-    fun onScanComplete(done: Boolean) = intent {
+    private fun onScanComplete(done: Boolean) = intent {
         reduce {
             state.copy(
                 isScanCompleted = done
@@ -88,7 +82,7 @@ class ScanBeforeViewModel @Inject constructor(
         }
     }
 
-    fun onOcrResult(scanAnalyze: ScanAnalyze) = intent {
+    private fun onOcrResult(scanAnalyze: ScanAnalyze) = intent {
         reduce {
             state.copy(
                 ocrResult = scanAnalyze

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/screenshot/LocalScreenshotViewModel.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/screenshot/LocalScreenshotViewModel.kt
@@ -3,16 +3,24 @@ package com.keeply.presentation.ui.scan.screenshot
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
+import com.keeply.domain.usecase.scan.GetScanOnBoardingVisibilityUseCase
 import com.keeply.domain.usecase.screenshot.GetLocalScreenshotsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
 class LocalScreenshotViewModel @Inject constructor(
-    getLocalScreenshotsUseCase: GetLocalScreenshotsUseCase
+    getLocalScreenshotsUseCase: GetLocalScreenshotsUseCase,
+    getScanOnBoardingVisibilityUseCase: GetScanOnBoardingVisibilityUseCase,
 ) : ViewModel() {
 
     val screenshots = getLocalScreenshotsUseCase()
         .flow
         .cachedIn(viewModelScope)
+
+    // 온보딩 모달 노출 여부
+    val showOnBoardingModal = getScanOnBoardingVisibilityUseCase()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 }

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/screenshot/ScreenshotScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/screenshot/ScreenshotScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -33,15 +35,16 @@ import com.keeply.presentation.core.theme.neutral100
 @Composable
 fun ScreenshotRoute(
     onBack: () -> Unit,
-    onNavigateToDetail: (Uri) -> Unit,
+    onNavigateToScanBefore: (Uri, Boolean) -> Unit,
     viewModel: LocalScreenshotViewModel = hiltViewModel()
 ) {
     val lazyPagingItems = viewModel.screenshots.collectAsLazyPagingItems()
+    val isShowOnBoarding by viewModel.showOnBoardingModal.collectAsState()
 
     ScreenshotScreen(
         lazyPagingItems = lazyPagingItems,
         onBack = onBack,
-        onNavigateToDetail = onNavigateToDetail,
+        onNavigateToDetail = { uri -> onNavigateToScanBefore(uri, isShowOnBoarding) },
     )
 }
 


### PR DESCRIPTION
## 작업 내용
- 스캔 온보딩모달에서 '다시보지않기' 후 다른 이이미를 선택하여 다시 스캔 화면(ScanBefore) 진입하면 깜빡거리는 이슈 수정 
<br>

## 확인 사항
- [x] 스캔탭 > '다시보지않기' 클릭 > 뒤로가기 > 다른 이미지 선택 > 온보딩모달이 노출되지 않고, 화면이 깜빡이지도 않는 것 확인
<br>

## 참고
- API스펙변경이 KP-210 브랜치에 적용돼있어서 KP-210로 일단 타겟브랜치 설정했어여

<br>