### PR TITLE
[KP-214] 스캔, 크롭화면 추가 수정

### DIFF
--- a/presentation/src/main/java/com/keeply/presentation/core/components/NavigationBar.kt
+++ b/presentation/src/main/java/com/keeply/presentation/core/components/NavigationBar.kt
@@ -2,12 +2,10 @@ package com.keeply.presentation.core.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -16,7 +14,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -90,9 +87,9 @@ private fun NavigationBarCenterItem(
         contentAlignment = Alignment.Center
     ) {
         Icon(
-            painter = KeeplyTheme.icons.scanAlt,
+            painter = KeeplyTheme.icons.add,
             contentDescription = "Scan",
-            modifier = Modifier.size(24.dp),
+            modifier = Modifier.size(28.dp),
             tint = Color.White
         )
     }

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/crop/CropOverlay.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/crop/CropOverlay.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
@@ -14,12 +17,13 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathFillType
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.keeply.presentation.core.theme.neutralBlack
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -28,6 +32,7 @@ import kotlin.math.min
 fun CropOverlay(
     modifier: Modifier = Modifier,
     cropRect: Rect,
+    initialCropRect: Rect,
     onCropRectChange: (Rect) -> Unit,
     imageSize: Size
 ) {
@@ -82,6 +87,7 @@ fun CropOverlay(
         ) {
             drawCropOverlay(
                 cropRect = cropRect,
+                initialCropRect = initialCropRect,
                 imageSize = imageSize,
                 canvasSize = size,
                 handleSize = handleSize
@@ -92,12 +98,25 @@ fun CropOverlay(
 
 private fun DrawScope.drawCropOverlay(
     cropRect: Rect,
+    initialCropRect: Rect,
     imageSize: Size,
     canvasSize: Size,
     handleSize: Float
 ) {
     // 투명한 배경 - 어두운 오버레이 제거
-    
+    val overlayColor = neutralBlack.copy(alpha = 0.2f)
+
+    val path = Path().apply {
+        addRect(initialCropRect) // 이미지 원본 영역
+        addRect(cropRect) // 크롭 영역
+        fillType = PathFillType.EvenOdd
+    }
+
+    drawPath(
+        path = path,
+        color = overlayColor
+    )
+
     // 크롭 영역 테두리
     drawRect(
         color = Color.White,

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/crop/CropScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/crop/CropScreen.kt
@@ -8,9 +8,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Icon
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
@@ -20,16 +23,14 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
-import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
-import com.keeply.presentation.core.theme.KeeplyTheme
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
+import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.rememberAsyncImagePainter
 import com.keeply.presentation.R
 import com.keeply.presentation.core.components.CropBar
-import com.keeply.presentation.core.components.KeeplyAppBar
-import com.keeply.presentation.core.components.KeeplyText
+import com.keeply.presentation.core.theme.KeeplyTheme
 import org.orbitmvi.orbit.compose.collectAsState
 
 @Composable
@@ -80,6 +81,7 @@ fun CropScreen(
     val density = LocalDensity.current
     var actualImageSize by remember { mutableStateOf(Size.Zero) }
     var localCropRect by remember { mutableStateOf(Rect.Zero) }
+    var initialCropRect by remember { mutableStateOf(Rect.Zero) }
     var isInitialized by remember { mutableStateOf(false) }
     var intrinsicImageSize by remember { mutableStateOf(Size.Zero) }
     
@@ -148,12 +150,11 @@ fun CropScreen(
                         val offsetY = (actualImageSize.height - displayedHeight) / 2f
                         
                         // 실제 표시되는 이미지 영역에 맞춰 초기 크롭 영역 설정
-                        val margin = 0.02f // 아주 작은 마진 (2%)
-                        val initialCropRect = Rect(
-                            left = offsetX + (displayedWidth * margin),
-                            top = offsetY + (displayedHeight * margin),
-                            right = offsetX + (displayedWidth * (1f - margin)),
-                            bottom = offsetY + (displayedHeight * (1f - margin))
+                        initialCropRect = Rect(
+                            left = offsetX,
+                            top = offsetY,
+                            right = offsetX + displayedWidth,
+                            bottom = offsetY + displayedHeight
                         )
                         localCropRect = initialCropRect
                         onCropRectChange(initialCropRect)
@@ -169,6 +170,7 @@ fun CropScreen(
                         )
                         .fillMaxSize(),
                     cropRect = localCropRect,
+                    initialCropRect = initialCropRect,
                     onCropRectChange = { newRect ->
                         localCropRect = newRect
                         onCropRectChange(newRect)

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeScreen.kt
@@ -112,10 +112,30 @@ fun ScanBeforeScreen(
     var isMenuVisible by remember { mutableStateOf(true) }
     var isScanLoading by remember { mutableStateOf(false) }
 
+    val interactionSource = remember { MutableInteractionSource() }
+    val clickableModifier = if (isScanLoading) {
+        Modifier
+            .padding(35.dp)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = { }
+            )
+    } else {
+        Modifier
+            .padding(0.dp)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = LocalIndication.current,
+                onClick = { isMenuVisible = !isMenuVisible }
+            )
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(neutral900)
+            .then(clickableModifier)
     ) {
 
         if (isShowOnBoarding) {
@@ -125,31 +145,11 @@ fun ScanBeforeScreen(
             )
         }
 
-        val interactionSource = remember { MutableInteractionSource() }
-        val clickableModifier = if (isScanLoading) {
-            Modifier
-                .padding(35.dp)
-                .clickable(
-                    interactionSource = interactionSource,
-                    indication = null,
-                    onClick = { }
-                )
-        } else {
-            Modifier
-                .padding(0.dp)
-                .clickable(
-                    interactionSource = interactionSource,
-                    indication = LocalIndication.current,
-                    onClick = { isMenuVisible = !isMenuVisible }
-                )
-        }
-
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight()
                 .align(Alignment.Center)
-                .then(clickableModifier)
         ) {
             val painter = if (LocalInspectionMode.current) {
                 painterResource(id = R.drawable.img_onboarding_02)

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanbefore/ScanBeforeScreen.kt
@@ -113,29 +113,20 @@ fun ScanBeforeScreen(
     var isScanLoading by remember { mutableStateOf(false) }
 
     val interactionSource = remember { MutableInteractionSource() }
-    val clickableModifier = if (isScanLoading) {
-        Modifier
-            .padding(35.dp)
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null,
-                onClick = { }
-            )
-    } else {
-        Modifier
-            .padding(0.dp)
-            .clickable(
-                interactionSource = interactionSource,
-                indication = LocalIndication.current,
-                onClick = { isMenuVisible = !isMenuVisible }
-            )
-    }
 
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(neutral900)
-            .then(clickableModifier)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = if (isScanLoading) null else LocalIndication.current,
+                onClick = {
+                    if (isScanLoading.not()) {
+                        isMenuVisible = !isMenuVisible
+                    }
+                }
+            )
     ) {
 
         if (isShowOnBoarding) {
@@ -147,6 +138,7 @@ fun ScanBeforeScreen(
 
         Box(
             modifier = Modifier
+                .padding(if (isScanLoading) 35.dp else 0.dp)
                 .fillMaxWidth()
                 .wrapContentHeight()
                 .align(Alignment.Center)


### PR DESCRIPTION
## 작업 내용
- 크롭영역 외부 오버레이 추가
- ScanBefore 클릭 영역 수정
- 네비게이션바 스캔버튼 소매넣기까지~

<br>

## 확인 사항
- [x] 크롭영역 외부 오버레이<br><img width="200" alt="image" src="https://github.com/user-attachments/assets/0371d130-3c52-4cd2-b871-7955d935686a" />

- [x] ScanBefore 에서 가로로 긴 이미지가 있을 때 이미지 윗 부분 터치해도 메뉴바가 사라져야 함
- [x] 네비게이션바 스캔버튼 아이콘 변경 <br><img width="170"  alt="image" src="https://github.com/user-attachments/assets/9e5dc8af-16d9-44bd-bf7f-79f989df1421" />

<br>

## 참고
-
<br>