### PR TITLE
[KP-602] 권한설정 디테일, UI 추가 

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,8 @@ clarity = "3.4.3"
 
 kakaoSdk = "2.21.4"
 
+accompanist = "0.37.3"
+
 [libraries]
 javapoet = { module = "com.squareup:javapoet", version.ref = "javapoet" }
 tools-build-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
@@ -120,6 +122,9 @@ serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serializ
 
 ## 카카오
 kakao-user-sdk = { module = "com.kakao.sdk:v2-user", version.ref = "kakaoSdk" }
+
+## accompanist
+accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -70,5 +70,7 @@ dependencies {
     implementation(libs.paging.runtime)
     implementation(libs.paging.compose)
 
+    implementation(libs.accompanist.permissions)
+
     hiltDependency()
 }

--- a/presentation/src/main/java/com/keeply/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/home/HomeScreen.kt
@@ -69,8 +69,6 @@ fun HomeRoute(
     val uiState by viewModel.collectAsState()
     val lazyPagingItems = viewModel.screenshots.collectAsLazyPagingItems()
 
-    viewModel.setRestrictService(isPermissionGranted(context))
-
     LaunchedEffect(Unit) {
         viewModel.loadHomeData()
     }
@@ -108,8 +106,9 @@ fun HomeScreen(
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
+                // '전체 허용'이 아닌 경우 제한된 서비스 표시
                 val photoPermissionStatus = getPhotoPermissionStatus(context)
-                setRestrictService(photoPermissionStatus == ImagePermissionStatus.FULL_ACCESS)
+                setRestrictService(photoPermissionStatus != ImagePermissionStatus.FULL_ACCESS)
             }
         }
         screenLifecycleOwner.lifecycle.addObserver(observer)

--- a/presentation/src/main/java/com/keeply/presentation/ui/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/home/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -30,6 +31,9 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -46,6 +50,8 @@ import com.keeply.presentation.ui.home.component.HomeKeeplyFolderItem
 import com.keeply.presentation.ui.home.component.HomeKeeplyScreenshotItem
 import com.keeply.presentation.ui.home.component.HomeUncategorizedCard
 import com.keeply.presentation.ui.home.component.KeeplyProgressBar
+import com.keeply.presentation.ui.permission.ImagePermissionStatus
+import com.keeply.presentation.util.getPhotoPermissionStatus
 import com.keeply.presentation.util.isPermissionGranted
 import com.keeply.presentation.util.openAppSettings
 import kotlinx.collections.immutable.toPersistentList
@@ -75,6 +81,7 @@ fun HomeRoute(
         lazyPagingItems = lazyPagingItems,
         isRestricted = uiState.isRestrictedService,
         latestScreenshotCount = viewModel.latestScreenshotCount,
+        setRestrictService = viewModel::setRestrictService,
         onClickSetting = { openAppSettings(context) },
         onClickUncategorized = onClickUncategorized,
         onClickFolder = onClickFolder,
@@ -88,11 +95,29 @@ fun HomeScreen(
     lazyPagingItems: LazyPagingItems<Screenshot>,
     isRestricted: Boolean = false,
     latestScreenshotCount: Int = 10,
+    setRestrictService: (Boolean) -> Unit = {},
     onClickSetting: () -> Unit = {},
     onClickUncategorized: () -> Unit = {},
     onClickFolder: () -> Unit = {},
     onClickScreenshot: (String) -> Unit = {}
 ) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val screenLifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                val photoPermissionStatus = getPhotoPermissionStatus(context)
+                setRestrictService(photoPermissionStatus == ImagePermissionStatus.FULL_ACCESS)
+            }
+        }
+        screenLifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            screenLifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
     state.homeData?.let { homeData ->
         Column(
             modifier = Modifier

--- a/presentation/src/main/java/com/keeply/presentation/ui/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/home/HomeViewModel.kt
@@ -42,10 +42,10 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun setRestrictService(restrict: Boolean) = intent {
-        reduce { state.copy(isRestrictedService = restrict) }
+    fun setRestrictService(isRestricted: Boolean) = intent {
+        reduce { state.copy(isRestrictedService = isRestricted) }
 
-        if (restrict.not()) {
+        if (isRestricted.not()) {
             screenshots = getLocalScreenshotsUseCase(pageSize = latestScreenshotCount)
                 .flow
                 .cachedIn(viewModelScope)

--- a/presentation/src/main/java/com/keeply/presentation/ui/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/home/HomeViewModel.kt
@@ -19,13 +19,13 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val getHomeDataUseCase: GetHomeDataUseCase,
-    getLocalScreenshotsUseCase: GetLocalScreenshotsUseCase
+    private val getLocalScreenshotsUseCase: GetLocalScreenshotsUseCase
 ) : ContainerHost<HomeState, HomeSideEffect>, ViewModel() {
     override val container: Container<HomeState, HomeSideEffect> = container(HomeState())
 
     val latestScreenshotCount = 10
 
-    val screenshots = getLocalScreenshotsUseCase(pageSize = latestScreenshotCount)
+    var screenshots = getLocalScreenshotsUseCase(pageSize = latestScreenshotCount)
         .flow
         .cachedIn(viewModelScope)
 
@@ -42,7 +42,13 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun setRestrictService(granted: Boolean) = intent {
-        reduce { state.copy(isRestrictedService = !granted) }
+    fun setRestrictService(restrict: Boolean) = intent {
+        reduce { state.copy(isRestrictedService = restrict) }
+
+        if (restrict.not()) {
+            screenshots = getLocalScreenshotsUseCase(pageSize = latestScreenshotCount)
+                .flow
+                .cachedIn(viewModelScope)
+        }
     }
 }

--- a/presentation/src/main/java/com/keeply/presentation/ui/onboarding/OnboardingScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/onboarding/OnboardingScreen.kt
@@ -97,7 +97,6 @@ fun OnboardingRoute(
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun OnboardingScreen(
     uiState: OnboardingState,

--- a/presentation/src/main/java/com/keeply/presentation/ui/permission/PermissionDeniedDialog.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/permission/PermissionDeniedDialog.kt
@@ -1,0 +1,78 @@
+package com.keeply.presentation.ui.permission
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.keeply.presentation.core.components.KeeplyButton
+import com.keeply.presentation.core.components.KeeplyButtonStyle
+import com.keeply.presentation.core.components.KeeplyText
+import com.keeply.presentation.core.theme.KeeplyTheme
+
+@Composable
+fun PermissionDeniedDialog(
+    onDismiss: () -> Unit = {},
+    onConfirm: () -> Unit = {}
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = KeeplyTheme.colors.neutralWhite
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                KeeplyText(
+                    text = "갤러리에 대한 권한 사용을 거부했습니다. 기능 사용을 원하실 경우 휴대폰 설정 > 애플리케이션 관리자에서 해당 앱의 권한을 허용해주세요.",
+                    style = KeeplyTheme.typography.body,
+                    color = KeeplyTheme.colors.neutralBlack,
+                    textAlign = TextAlign.Center
+                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 28.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    KeeplyButton(
+                        modifier = Modifier
+                            .weight(1f),
+                        text = "닫기",
+                        buttonStyle = KeeplyButtonStyle.SECONDARY,
+                        onClick = {
+                            onDismiss()
+                        }
+                    )
+
+                    KeeplyButton(
+                        modifier = Modifier
+                            .weight(1f),
+                        text = "권한 설정",
+                        onClick = {
+                            onConfirm()
+                        }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/screenshot/LocalScreenshotViewModel.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/screenshot/LocalScreenshotViewModel.kt
@@ -5,20 +5,44 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import com.keeply.domain.usecase.scan.GetScanOnBoardingVisibilityUseCase
 import com.keeply.domain.usecase.screenshot.GetLocalScreenshotsUseCase
+import com.keeply.presentation.ui.onboarding.OnboardingSideEffect
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
 @HiltViewModel
 class LocalScreenshotViewModel @Inject constructor(
-    getLocalScreenshotsUseCase: GetLocalScreenshotsUseCase,
+    private val getLocalScreenshotsUseCase: GetLocalScreenshotsUseCase,
     getScanOnBoardingVisibilityUseCase: GetScanOnBoardingVisibilityUseCase,
-) : ViewModel() {
+) : ContainerHost<ScreenshotState, ScreenshotSideEffect>, ViewModel() {
 
-    val screenshots = getLocalScreenshotsUseCase()
-        .flow
-        .cachedIn(viewModelScope)
+    override val container: Container<ScreenshotState, ScreenshotSideEffect> =
+        container(ScreenshotState())
+
+    fun loadScreenshots() = intent {
+        val flow = getLocalScreenshotsUseCase().flow.cachedIn(viewModelScope)
+        reduce { state.copy(screenshotsFlow = flow) }
+    }
+
+    fun setRestrictService(isRestricted: Boolean) = intent {
+        reduce {
+            state.copy(
+                isRestricted = isRestricted
+            )
+        }
+    }
+
+    fun requestPermission() = intent {
+        postSideEffect(ScreenshotSideEffect.RequestPermission)
+    }
+
+    fun setPermissionDeniedDialog(isShow: Boolean) = intent {
+        reduce { state.copy(showPermissionDeniedDialog = isShow) }
+    }
 
     // 온보딩 모달 노출 여부
     val showOnBoardingModal = getScanOnBoardingVisibilityUseCase()

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/screenshot/ScreenshotScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/screenshot/ScreenshotScreen.kt
@@ -207,7 +207,7 @@ fun ScreenshotFrame(
 ) {
     Column(
         modifier = Modifier
-            .fillMaxHeight()
+            .fillMaxSize()
     ) {
         Column(
             modifier = Modifier

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/screenshot/ScreenshotScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/screenshot/ScreenshotScreen.kt
@@ -1,27 +1,39 @@
 package com.keeply.presentation.ui.scan.screenshot
 
 import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import coil.compose.rememberAsyncImagePainter
@@ -31,6 +43,14 @@ import com.keeply.presentation.core.components.KeeplyAppBar
 import com.keeply.presentation.core.components.KeeplyText
 import com.keeply.presentation.core.theme.KeeplyTheme
 import com.keeply.presentation.core.theme.neutral100
+import com.keeply.presentation.ui.permission.ImagePermissionStatus
+import com.keeply.presentation.ui.permission.PermissionDeniedDialog
+import com.keeply.presentation.ui.permission.PermissionUpgradeDialog
+import com.keeply.presentation.util.getPhotoPermissionStatus
+import com.keeply.presentation.util.getRequiredImagePermission
+import com.keeply.presentation.util.openAppSettings
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
 fun ScreenshotRoute(
@@ -38,12 +58,35 @@ fun ScreenshotRoute(
     onNavigateToScanBefore: (Uri, Boolean) -> Unit,
     viewModel: LocalScreenshotViewModel = hiltViewModel()
 ) {
-    val lazyPagingItems = viewModel.screenshots.collectAsLazyPagingItems()
+    val context = LocalContext.current
+    val uiState by viewModel.collectAsState()
+    val lazyPagingItems = uiState.screenshotsFlow.collectAsLazyPagingItems()
     val isShowOnBoarding by viewModel.showOnBoardingModal.collectAsState()
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        viewModel.setPermissionDeniedDialog(!isGranted)
+    }
+
+    viewModel.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is ScreenshotSideEffect.RequestPermission -> permissionLauncher.launch(
+                getRequiredImagePermission()
+            )
+        }
+    }
 
     ScreenshotScreen(
         lazyPagingItems = lazyPagingItems,
+        isRestricted = uiState.isRestricted,
+        showPermissionDeniedDialog = uiState.showPermissionDeniedDialog,
         onBack = onBack,
+        setRestrictService = viewModel::setRestrictService,
+        setPermissionDeniedDialog = viewModel::setPermissionDeniedDialog,
+        onRequestPermission = { viewModel.requestPermission() },
+        onClickSetting = { openAppSettings(context) },
+        onLoadScreenshots = { viewModel.loadScreenshots() },
         onNavigateToDetail = { uri -> onNavigateToScanBefore(uri, isShowOnBoarding) },
     )
 }
@@ -51,14 +94,57 @@ fun ScreenshotRoute(
 @Composable
 fun ScreenshotScreen(
     lazyPagingItems: LazyPagingItems<Screenshot>,
+    isRestricted: Boolean = false,
+    showPermissionDeniedDialog: Boolean,
     onBack: () -> Unit,
-    onNavigateToDetail: (Uri) -> Unit,
+    setRestrictService: (Boolean) -> Unit = {},
+    setPermissionDeniedDialog: (Boolean) -> Unit = {},
+    onRequestPermission: () -> Unit = {},
+    onClickSetting: () -> Unit = {},
+    onLoadScreenshots: () -> Unit = {},
+    onNavigateToDetail: (Uri) -> Unit
 ) {
-    // TODO: 화면 재진입 시 스샷목록 새로고침
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val screenLifecycleOwner = LocalLifecycleOwner.current
+
+    var showUpgradeDialog by remember { mutableStateOf(false) }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                // '제한된 액세스 허용'일 때만 제한된 서비스 표시
+                val photoPermissionStatus = getPhotoPermissionStatus(context)
+                when (photoPermissionStatus) {
+                    ImagePermissionStatus.FULL_ACCESS -> {
+                        setRestrictService(false)
+                    }
+
+                    ImagePermissionStatus.PARTIAL_ACCESS -> {
+                        setRestrictService(true)
+                    }
+
+                    ImagePermissionStatus.NO_ACCESS -> {
+                        setRestrictService(false)
+                        showUpgradeDialog = true
+                    }
+                }
+
+                // resume시 목록 갱신
+                onLoadScreenshots()
+            }
+        }
+        screenLifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            screenLifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
 
     ScreenshotFrame(
         count = lazyPagingItems.itemCount,
-        onBack = onBack
+        isRestricted = isRestricted,
+        onBack = onBack,
+        onClickSetting = onClickSetting
     ) {
         LazyVerticalGrid(
             columns = GridCells.Fixed(3),
@@ -81,52 +167,117 @@ fun ScreenshotScreen(
             }
         }
     }
+
+    if (showUpgradeDialog) {
+        PermissionUpgradeDialog(
+            onDismiss = {
+                showUpgradeDialog = false
+                setPermissionDeniedDialog(true)
+            },
+            onConfirm = {
+                // 시스템 다이얼로그 노출
+                onRequestPermission()
+                showUpgradeDialog = false
+            }
+        )
+    }
+
+    if (showPermissionDeniedDialog) {
+        PermissionDeniedDialog(
+            onDismiss = {
+                setPermissionDeniedDialog(false)
+                onBack()
+            },
+            onConfirm = {
+                // 설정 으로 이동
+                openAppSettings(context)
+                setPermissionDeniedDialog(false)
+            }
+        )
+    }
 }
 
 @Composable
 fun ScreenshotFrame(
-    modifier: Modifier = Modifier,
-    onBack: () -> Unit,
     count: Int = 0,
+    isRestricted: Boolean = false,
+    onBack: () -> Unit,
+    onClickSetting: () -> Unit = {},
     content: @Composable ColumnScope.() -> Unit
 ) {
     Column(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxHeight()
-            .background(neutral100)
     ) {
-        KeeplyAppBar(
-            customTitleContent = {
+        Column(
+            modifier = Modifier
+                .background(neutral100)
+                .weight(1f)
+        ) {
+            KeeplyAppBar(
+                customTitleContent = {
+                    Row(
+                        modifier = Modifier
+                            .padding(start = 12.dp)
+                            .align(Alignment.CenterStart),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.Bottom
+                    ) {
+                        KeeplyText(
+                            text = "Screenshots",
+                            style = KeeplyTheme.typography.header03,
+                        )
+
+                        KeeplyText(
+                            text = "$count",
+                            style = KeeplyTheme.typography.header04,
+                            color = KeeplyTheme.colors.neutral500
+                        )
+                    }
+                },
+                leadingIcon = {
+                    Icon(
+                        painter = KeeplyTheme.icons.chevronLeft,
+                        contentDescription = "Back",
+                        tint = KeeplyTheme.colors.neutralBlack
+                    )
+                },
+                onClickLeading = onBack
+            )
+
+            content()
+        }
+
+        if (isRestricted) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding()
+                    .background(KeeplyTheme.colors.neutral200)
+                    .clickable { onClickSetting() },
+                contentAlignment = Alignment.BottomCenter
+            ) {
                 Row(
                     modifier = Modifier
-                        .padding(start = 12.dp)
-                        .align(Alignment.CenterStart),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.Bottom
+                        .fillMaxWidth()
+                        .padding(all = 18.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     KeeplyText(
-                        text = "Screenshots",
-                        style = KeeplyTheme.typography.header03,
+                        text = "Keeply가 선택한 수의 사진에만 액세스하도록 허용합니다.",
+                        style = KeeplyTheme.typography.caption02,
+                        color = KeeplyTheme.colors.neutral800
                     )
 
                     KeeplyText(
-                        text = "$count",
-                        style = KeeplyTheme.typography.header04,
-                        color = KeeplyTheme.colors.neutral500
+                        text = "관리",
+                        style = KeeplyTheme.typography.button01Suit,
+                        color = KeeplyTheme.colors.neutral900
                     )
                 }
-            },
-            leadingIcon = {
-                Icon(
-                    painter = KeeplyTheme.icons.chevronLeft,
-                    contentDescription = "Back",
-                    tint = KeeplyTheme.colors.neutralBlack
-                )
-            },
-            onClickLeading = onBack
-        )
-
-        content()
+            }
+        }
     }
 }
 
@@ -135,7 +286,9 @@ fun ScreenshotFrame(
 private fun ScanScreenPreview() {
     KeeplyTheme {
         ScreenshotFrame(
-            onBack = { }
+            onBack = { },
+            isRestricted = true,
+            onClickSetting = { }
         ) {
             KeeplyText(
                 text = "Contents",

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/screenshot/ScreenshotState.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/screenshot/ScreenshotState.kt
@@ -1,0 +1,18 @@
+package com.keeply.presentation.ui.scan.screenshot
+
+import androidx.compose.runtime.Immutable
+import androidx.paging.PagingData
+import com.keeply.domain.model.Screenshot
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+@Immutable
+data class ScreenshotState(
+    val screenshotsFlow: Flow<PagingData<Screenshot>> = flowOf(PagingData.empty()),
+    val isRestricted: Boolean = false,
+    val showPermissionDeniedDialog: Boolean = false
+)
+
+sealed interface ScreenshotSideEffect {
+    data object RequestPermission : ScreenshotSideEffect
+}

--- a/presentation/src/main/java/com/keeply/presentation/util/PermissionUtil.kt
+++ b/presentation/src/main/java/com/keeply/presentation/util/PermissionUtil.kt
@@ -51,3 +51,41 @@ fun checkImagePermissions(context: Context): ImagePermissionStatus {
         }
     }
 }
+
+fun getPhotoPermissionStatus(context: Context): ImagePermissionStatus {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        // API 34 이상 → 부분 접근 권한까지 체크
+        val hasFullAccess = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.READ_MEDIA_IMAGES
+        ) == PackageManager.PERMISSION_GRANTED
+
+        // 제한적 허용
+        val hasPartialAccess = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED
+        ) == PackageManager.PERMISSION_GRANTED
+
+        when {
+            hasFullAccess -> ImagePermissionStatus.FULL_ACCESS
+            hasPartialAccess -> ImagePermissionStatus.PARTIAL_ACCESS
+            else -> ImagePermissionStatus.NO_ACCESS
+        }
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        // API 33 → 모든 사진 접근만 있음
+        val hasFullAccess = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.READ_MEDIA_IMAGES
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (hasFullAccess) ImagePermissionStatus.FULL_ACCESS else ImagePermissionStatus.NO_ACCESS
+    } else {
+        // API 32 이하 → READ_EXTERNAL_STORAGE 사용
+        val hasLegacyAccess = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (hasLegacyAccess) ImagePermissionStatus.FULL_ACCESS else ImagePermissionStatus.NO_ACCESS
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 홈, 스캔 탭에서 권한설정
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ee6b8b24-60b6-49de-993a-b20206aed5f6" />
대략 이런 느낌입니다..

- 홈
  - 모두허용) 전체기능가능
  - 일부허용, 허용안함) 상단에 안내문, 안내문 클릭시 설정으로 이동, '최신 스크린샷' 제거
- 스캔탭
  - 모두허용) 전체기능가능
  - 일부허용) 하단에 안내문, 안내문 클릭시 설정으로 이동
  - 허용안함) 모달띄움 -> 클릭시 권한요청모달 -> 2차 권한 거부시 안내모달 -> 설정으로 이동

|홈|스캔|스캔모달|
|--|--|--|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/7774a0c8-d6be-4463-a280-f8b512f6e7a3" />|<img width="300" alt="image" src="https://github.com/user-attachments/assets/6b28d0eb-518f-426a-a74e-4a904181f7fc" />|<img width="300" alt="image" src="https://github.com/user-attachments/assets/add22031-bba6-4a34-ac4b-4ff929e4d55f" />|


<br>

## 확인 사항
- [ ] 권한설정하는곳 체크 
<br>

## 참고
- 시스템모달에서 권한설정을 하면 모두허용과 일부허용이 구분되지 않습니다🥲 (안드로이드 버그인듯?)
- 위 플로우는 최초 권한 설정 이후라고 생각하심 됩니다 
<br>