### PR TITLE
[KP-204-3] imageFrame 이미지사이즈에 맞춘버전 추가

### DIFF
--- a/presentation/src/main/java/com/keeply/presentation/core/components/OriginalSizeImageFrame.kt
+++ b/presentation/src/main/java/com/keeply/presentation/core/components/OriginalSizeImageFrame.kt
@@ -1,0 +1,91 @@
+package com.keeply.presentation.core.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImagePainter
+import coil.compose.SubcomposeAsyncImage
+import coil.compose.SubcomposeAsyncImageContent
+import com.keeply.presentation.core.theme.KeeplyTheme
+import com.keeply.presentation.core.theme.neutral800
+import com.keeply.presentation.extend.shadow01
+
+@Composable
+fun OriginalSizeImageFrame(
+    modifier: Modifier = Modifier,
+    imageUrl: String,
+) {
+    Card(
+        modifier = modifier
+            .wrapContentSize()
+            .shadow01(),
+        shape = RoundedCornerShape(2.dp),
+        border = BorderStroke(6.dp, KeeplyTheme.colors.neutralWhite),
+        colors = CardDefaults.cardColors(
+            containerColor = KeeplyTheme.colors.neutralWhite
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(2.dp)
+                .clip(RoundedCornerShape(2.dp))
+        ) {
+            SubcomposeAsyncImage(
+                model = imageUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                val state = painter.state
+                if (state is AsyncImagePainter.State.Success) {
+                    val ratio = state.painter.intrinsicSize.width / state.painter.intrinsicSize.height
+                    SubcomposeAsyncImageContent(
+                        modifier = Modifier.aspectRatio(ratio)
+                    )
+                } else {
+                    // 로딩 상태 placeholder
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(16 / 9f) // 기본 비율
+                            .background(KeeplyTheme.colors.neutral200)
+                    )
+                }
+            }
+        }
+    }
+}
+
+
+
+@Preview(showBackground = true)
+@Composable
+fun FlexibleImageFramePreview() {
+    KeeplyTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(neutral800)
+                .padding(20.dp)
+        ) {
+            OriginalSizeImageFrame(
+                imageUrl = ""
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/keeply/presentation/ui/folder/screenshot/DetailScreenshotScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/folder/screenshot/DetailScreenshotScreen.kt
@@ -15,17 +15,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.rememberAsyncImagePainter
 import com.keeply.presentation.R
 import com.keeply.presentation.core.components.FileTag
 import com.keeply.presentation.core.components.FileTagStyle
-import com.keeply.presentation.core.components.ImageFrame
+import com.keeply.presentation.core.components.OriginalSizeImageFrame
 import com.keeply.presentation.core.components.InsightTextField
 import com.keeply.presentation.core.components.KeeplyAppBar
 import com.keeply.presentation.core.components.KeeplyText
@@ -124,17 +121,11 @@ fun DetailScreenshotScreen(
                 }
             }
             item {
-                val painter = if (LocalInspectionMode.current) {
-                    painterResource(id = R.drawable.img_onboarding_02)
-                } else {
-                    rememberAsyncImagePainter(model = presignedUrl)
-                }
-
-                ImageFrame(
-                    painter = painter,
+                OriginalSizeImageFrame(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = 10.dp, bottom = 18.dp),
+                    imageUrl = presignedUrl
                 )
             }
 

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/ScanEditAndSaveScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/ScanEditAndSaveScreen.kt
@@ -17,22 +17,19 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberAsyncImagePainter
 import com.keeply.domain.folder.model.Folder
 import com.keeply.presentation.R
 import com.keeply.presentation.core.components.FolderList
-import com.keeply.presentation.core.components.OriginalSizeImageFrame
 import com.keeply.presentation.core.components.InsightTextField
 import com.keeply.presentation.core.components.KeeplyButton
 import com.keeply.presentation.core.components.KeeplyButtonSize
 import com.keeply.presentation.core.components.KeeplyButtonStyle
 import com.keeply.presentation.core.components.KeeplyIconButton
 import com.keeply.presentation.core.components.KeeplyText
+import com.keeply.presentation.core.components.OriginalSizeImageFrame
 import com.keeply.presentation.core.theme.KeeplyTheme
 import com.keeply.presentation.core.theme.neutral100
 import kotlinx.collections.immutable.ImmutableList
@@ -41,7 +38,7 @@ import java.net.URLDecoder
 
 @Composable
 fun ScanEditAndSaveScreen(
-    uri: Uri? = null,
+    uri: Uri,
     textField: String,
     textFieldLength: Int,
     textFieldMaxLength: Int,
@@ -66,19 +63,12 @@ fun ScanEditAndSaveScreen(
                 .weight(1f)
                 .padding(horizontal = 16.dp)
         ) {
-            // TODO: image사이즈에 맞춰지도록 수정 필요
             item {
-                val painter = if (LocalInspectionMode.current) {
-                    painterResource(id = R.drawable.img_onboarding_02)
-                } else {
-                    rememberAsyncImagePainter(URLDecoder.decode(uri.toString(), "UTF-8"))
-                }
-
                 OriginalSizeImageFrame(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = 19.dp, bottom = 40.dp),
-                    imageUrl = uri.toString()
+                    imageUrl = URLDecoder.decode(uri.toString(), "UTF-8")
                 )
             }
 
@@ -166,6 +156,7 @@ fun ScanEditAndSaveScreen(
 private fun ScanScreenPreview() {
     KeeplyTheme {
         ScanEditAndSaveScreen(
+            uri = Uri.EMPTY,
             textField = "",
             textFieldLength = 0,
             textFieldMaxLength = 300,

--- a/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/ScanEditAndSaveScreen.kt
+++ b/presentation/src/main/java/com/keeply/presentation/ui/scan/scanafter/ScanEditAndSaveScreen.kt
@@ -26,7 +26,7 @@ import coil.compose.rememberAsyncImagePainter
 import com.keeply.domain.folder.model.Folder
 import com.keeply.presentation.R
 import com.keeply.presentation.core.components.FolderList
-import com.keeply.presentation.core.components.ImageFrame
+import com.keeply.presentation.core.components.OriginalSizeImageFrame
 import com.keeply.presentation.core.components.InsightTextField
 import com.keeply.presentation.core.components.KeeplyButton
 import com.keeply.presentation.core.components.KeeplyButtonSize
@@ -74,11 +74,11 @@ fun ScanEditAndSaveScreen(
                     rememberAsyncImagePainter(URLDecoder.decode(uri.toString(), "UTF-8"))
                 }
 
-                ImageFrame(
-                    painter = painter,
+                OriginalSizeImageFrame(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = 19.dp, bottom = 40.dp),
+                    imageUrl = uri.toString()
                 )
             }
 


### PR DESCRIPTION
## 작업 내용
- 기존 imageFrame은 비율이 고정이라서, 이미지사이즈에 맞춰서 적용되는 버전 추가했습니당. (스크린샷상세화면에서만 사용됨)
<img width="263" height="568" alt="image" src="https://github.com/user-attachments/assets/52772350-86a2-4b8d-9e40-22446fc20e8a" />

<br>

## 확인 사항
- [ ] 가로로 긴 사진이나 세로로 긴(9:16) 스크린샷으로 테스트 -> 1.저장할 때 상세화면 / 2.폴더내 상세화면
<br>

## 참고
-
<br>